### PR TITLE
add bylaws

### DIFF
--- a/bylaws.md
+++ b/bylaws.md
@@ -61,15 +61,15 @@ Section 6. Amendments to Bylaws
 
 These bylaws may be amended by the Committee at any time.
 
-Article III. Conflict Resolution
-================================
+Article III. Dispute Resolution
+===============================
 
 Section 1. Internal Resolution
 ------------------------------
 
-Any conflicts that arise between members of the Committee or contributors to Buildbot will typically be handled by the Committee.
+Any disputes that arise between members of the Committee or contributors to Buildbot will typically be handled in an ad-hoc fashion by the Committee.
 Contributors or Committee members are invited to record a grievance by emailing the Botherders mailing list, including the word "[GRIEVANCE]" in the subject.
-The Committee will keep Conservancy appraised of the status of conflicts during the resolution process.
+The Committee will keep Conservancy appraised of the status of disputes during the resolution process.
 
 In the event that no satisfactory resolution can be reached, the Representative will request investigation and assistance from Conservancy.
 Conservancy's decisions shall be considered binding on the Committee.


### PR DESCRIPTION
This is a short set of bylaws.  My goal here is to establish a bit of process _before_ we need it, as a means of avoiding conflict and ambiguity down the road.  This covers Botherders membership and governance, as well as a fairly simple conflict resolution process.  It should be enough to make sure Buildbot carries on merrily if I'm hit by a bus or lose my marbles an start doing stupid things.

I am, of course, open to all the review and criticism you'd like to make here, but fundamentally I'm no more interested in writing what is undoubtedly n00bish legalese than you are in reading it.  So if this looks basically un-offensive to you, then let's get it merged and move on.
