### PR TITLE
Recognize Tom Prince's resignation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Members
 
  * Dustin J. Mitchell
  * Bill Deegan (Representative to Conservancy)
- * Tom Prince
  * Amar Takhar
  * Pierre Tardy
  * Jared Grubb

--- a/votes/2018-04-29-tomprince-resigns
+++ b/votes/2018-04-29-tomprince-resigns
@@ -1,0 +1,14 @@
+
+I move to recognize Tom's resignation from the botherders[*] and additionally commend him for his incredible work on the project over the last 9 years.  Tom has an amazing attention to detail and strong sense of design[+], both of which contributed to making Buildbot a much more regular, predictable piece of software.
+
+Per the bylaws, please reply with your votes.
+
+Dustin
+
+[*] I don't think the bylaws require this, or provide for us to reject anyone's resignation, anyway
+[+] This is among the reasons I'm really glad Tom works at Mozilla now :)
+
+----
+
+PASSED
+In favor: Pierre Tardy, Bill Deegan, Dustin J. Mitchell


### PR DESCRIPTION
I will also
 * [x] remove tom from the botherders mailing list
 * [x] remove tom from the github group

Noting that
 * tom [does not have access to buildbot infra](https://github.com/buildbot/buildbot-infra/blob/ac6dcea2f52b163439cba73f7751bacd1769ddc6/group_vars/all#L43-L53)
 * tom remains a trusted member of the community so we are not concerned with any lingering access or rotation of secret keys

@bdbaddog could you
 * [x] inform conservancy of the change